### PR TITLE
Add PR list view and navigation UX refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ wtx
 
 Inside the picker:
 
+- `left`/`right`: switch between worktree view and PR view
 - `enter`: actions for selected free worktree
 - `s`: open shell in selected free worktree
 - `d`: delete selected worktree (with confirmation)
 - `u`: unlock selected locked worktree (with confirmation)
+- `p`: open selected worktree PR URL (worktree view)
+- `P`: open selected PR URL (PR view)
 - `r`: manual refresh (bypasses GH cache)
 - `q`: quit
 
@@ -55,6 +58,7 @@ Inside the picker:
   - PR link
   - CI status and progress
   - review summary
+  - open PR view ordered by most recently updated
 - Tmux integration:
   - auto-starts inside a fresh tmux session when launched outside tmux
   - custom bottom status line

--- a/worktree_orchestrator.go
+++ b/worktree_orchestrator.go
@@ -75,3 +75,13 @@ func (o *WorktreeOrchestrator) PRDataForStatusWithError(status WorktreeStatus, f
 	}
 	return o.prMgr.PRDataByBranch(status.RepoRoot, branches)
 }
+
+func (o *WorktreeOrchestrator) PRsForStatusWithError(status WorktreeStatus, force bool) ([]PRListData, error) {
+	if o == nil || o.prMgr == nil {
+		return []PRListData{}, nil
+	}
+	if !status.InRepo || strings.TrimSpace(status.RepoRoot) == "" {
+		return []PRListData{}, nil
+	}
+	return o.prMgr.PRs(status.RepoRoot, force)
+}


### PR DESCRIPTION
## Summary
- Add a dedicated PR list view alongside worktree view, navigable with horizontal arrows.
- Reuse/refactor existing GH manager fetching so one cache path serves both branch enrichment and PR list rows.
- Show all PRs sorted by most recently updated, with merged/closed rows styled as disabled.
- Keep previous PR rows visible while refreshing and show a PR-view spinner during load.
- Update key behavior so `p` opens the selected PR from PR view and retains worktree PR opening behavior.

## UI/UX changes
- Header now places `WTX` and the view tabs on the same top line.
- Simplified view hint styling and help text to use `←/→` notation.
- Added PR table columns: `PR | Branch | Title | CI status | Approval | PR status`.

## Data/fetch behavior
- Continue using `gh pr list --state all` and currently fetch up to `200` PRs.
- PR rows are sorted descending by `updatedAt`.
- Existing PR list state is preserved during refresh.

## Validation
- `gofmt` on touched files.
- `go test ./...` passes.
