### PR TITLE
Fix tmux wheel scrolling reliability + copy-mode styling

### DIFF
--- a/cmd/tmux_manager.go
+++ b/cmd/tmux_manager.go
@@ -399,6 +399,7 @@ func applyWTXSessionDefaults(sessionID string, enableDestroyUnattached bool) {
 	tmuxSetOption(sessionID, "key-table", keyTable)
 	configureTmuxStatusRefreshHooks(sessionID)
 	configureTmuxPaneBadgeBehavior(sessionID)
+	configureTmuxMouseBindings(keyTable)
 
 	// Only resize when split panes are present.
 	_ = exec.Command("tmux", "bind-key", "-r", "-T", keyTable, "M-Up", "if-shell", "-F", "#{>:#{window_panes},1}", "select-pane -U").Run()
@@ -416,6 +417,17 @@ func applyWTXSessionDefaults(sessionID string, enableDestroyUnattached bool) {
 	}
 
 	configureTmuxActionBindings(sessionID, resolveAgentLifecycleBinary())
+}
+
+func configureTmuxMouseBindings(keyTable string) {
+	keyTable = strings.TrimSpace(keyTable)
+	if keyTable == "" {
+		return
+	}
+	// Custom key tables do not inherit root mouse bindings, so re-bind border drag resize.
+	_ = exec.Command("tmux", "bind-key", "-T", keyTable, "MouseDown1Pane", "select-pane", "-t=").Run()
+	_ = exec.Command("tmux", "bind-key", "-T", keyTable, "MouseDown1Border", "select-pane", "-t=").Run()
+	_ = exec.Command("tmux", "bind-key", "-T", keyTable, "MouseDrag1Border", "resize-pane", "-M").Run()
 }
 
 type tmuxOption struct {

--- a/cmd/tmux_manager.go
+++ b/cmd/tmux_manager.go
@@ -15,7 +15,7 @@ import (
 )
 
 const tmuxStatusIntervalSeconds = "10"
-const tmuxStatusRightHint = " ^A actions | ^W back#{?#{>:#{window_panes},1}, | ⌥⇧↑/⌥⇧↓ resize,} "
+const tmuxStatusRightHint = " ^A actions | ^W back | ⌥[ scroll#{?#{>:#{window_panes},1}, | ⌥⇧↑/⌥⇧↓ resize,} "
 
 func ensureFreshTmuxSession(args []string) (bool, error) {
 	if tmuxIntegrationDisabled() {
@@ -70,6 +70,8 @@ func ensureFreshTmuxSession(args []string) (bool, error) {
 		if err := exec.Command("tmux", "switch-client", "-t", session).Run(); err != nil {
 			return false, err
 		}
+		// Re-apply after client switch so mouse/table bindings are set in attached context.
+		applyWTXSessionDefaults(session, false)
 		return true, nil
 	}
 
@@ -79,7 +81,7 @@ func ensureFreshTmuxSession(args []string) (bool, error) {
 	}
 
 	go func() {
-		waitForSessionClientAttach(session, 3*time.Second)
+		applyWTXSessionDefaults(session, false)
 		_ = tmuxSignal(launchToken)
 	}()
 
@@ -150,24 +152,6 @@ func tmuxSignal(signal string) error {
 		return nil
 	}
 	return exec.Command("tmux", "wait-for", "-S", signal).Run()
-}
-
-func waitForSessionClientAttach(sessionID string, timeout time.Duration) {
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return
-	}
-	deadline := time.Now().Add(timeout)
-	for {
-		out, err := exec.Command("tmux", "list-clients", "-t", sessionID, "-F", "#{client_pid}").Output()
-		if err == nil && strings.TrimSpace(string(out)) != "" {
-			return
-		}
-		if time.Now().After(deadline) {
-			return
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
 }
 
 func resolveSelfBinary(args []string) (string, error) {
@@ -325,7 +309,7 @@ func setDynamicWorktreeStatus(worktreePath string) {
 	_ = exec.Command("tmux", "set-environment", "-t", sessionID, "WTX_WORKTREE_PATH", worktreePath).Run()
 	tmuxSetOption(sessionID, "@wtx_worktree_path", worktreePath)
 	tmuxSetOption(sessionID, "status-left", " "+cmd+" ")
-	tmuxSetOption(sessionID, "status-right", " ^A actions | ^S split | ^P PR | ^L IDE#{?#{>:#{window_panes},1}, | ⌥↑/⌥↓ move | ⌥⇧↑/⌥⇧↓ resize,} ")
+	tmuxSetOption(sessionID, "status-right", " ^A actions | ^S split | ^P PR | ^L IDE | ⌥[ scroll#{?#{>:#{window_panes},1}, | ⌥↑/⌥↓ move | ⌥⇧↑/⌥⇧↓ resize,} ")
 	tmuxSetOption(sessionID, "status-right-length", "132")
 	titleCmd := "#(" + shellQuote(bin) + " tmux-title --worktree " + shellQuote(worktreePath) + ")"
 	tmuxSetOption(sessionID, "set-titles", "on")
@@ -424,10 +408,60 @@ func configureTmuxMouseBindings(keyTable string) {
 	if keyTable == "" {
 		return
 	}
-	// Custom key tables do not inherit root mouse bindings, so re-bind border drag resize.
-	_ = exec.Command("tmux", "bind-key", "-T", keyTable, "MouseDown1Pane", "select-pane", "-t=").Run()
-	_ = exec.Command("tmux", "bind-key", "-T", keyTable, "MouseDown1Border", "select-pane", "-t=").Run()
-	_ = exec.Command("tmux", "bind-key", "-T", keyTable, "MouseDrag1Border", "resize-pane", "-M").Run()
+	// Custom key tables do not inherit root/copy-mode bindings. Bind all relevant tables so wheel
+	// behavior is consistent even during table transitions.
+	for _, table := range []string{keyTable, "root", "copy-mode", "copy-mode-vi"} {
+		for _, binding := range tmuxMouseBindings(table) {
+			args := make([]string, 0, len(binding.args)+5)
+			args = append(args, "bind-key")
+			if binding.repeatable {
+				args = append(args, "-r")
+			}
+			args = append(args, "-T", table, binding.key)
+			args = append(args, binding.args...)
+			_ = exec.Command("tmux", args...).Run()
+		}
+	}
+}
+
+type tmuxBinding struct {
+	key        string
+	args       []string
+	repeatable bool
+}
+
+func tmuxMouseBindings(table string) []tmuxBinding {
+	table = strings.TrimSpace(table)
+	if table == "copy-mode" || table == "copy-mode-vi" {
+		return []tmuxBinding{
+			{key: "WheelUpPane", args: []string{"select-pane -t=; send-keys -X -N 1 scroll-up"}, repeatable: true},
+			{key: "WheelDownPane", args: []string{"select-pane -t=; send-keys -X -N 1 scroll-down"}, repeatable: true},
+		}
+	}
+	return []tmuxBinding{
+		{key: "MouseDown1Pane", args: []string{"select-pane", "-t="}},
+		{key: "MouseDown1Border", args: []string{"select-pane", "-t="}},
+		{key: "MouseDrag1Border", args: []string{"resize-pane", "-M"}},
+		{
+			key: "WheelUpPane",
+			args: []string{
+				"if-shell", "-F", "-t", "=", "#{||:#{alternate_on},#{mouse_any_flag}}",
+				"send-keys -M",
+				"select-pane -t=; copy-mode -e; send-keys -X -N 1 scroll-up",
+			},
+			repeatable: true,
+		},
+		{
+			key: "WheelDownPane",
+			args: []string{
+				"if-shell", "-F", "-t", "=", "#{||:#{alternate_on},#{mouse_any_flag}}",
+				"send-keys -M",
+				"select-pane -t=; copy-mode -e; send-keys -X -N 1 scroll-down",
+			},
+			repeatable: true,
+		},
+		{key: "M-[", args: []string{"copy-mode", "-e"}},
+	}
 }
 
 type tmuxOption struct {
@@ -439,6 +473,7 @@ func wtxPaneStyleOptions() []tmuxOption {
 	return []tmuxOption{
 		{key: "pane-border-style", value: "fg=#1e1530"},
 		{key: "pane-active-border-style", value: "fg=#6a4b9c"},
+		{key: "mode-style", value: "fg=#1e1530,bg=#6a4b9c"},
 		{key: "pane-border-lines", value: "heavy"},
 		{key: "pane-border-status", value: "off"},
 		{key: "pane-border-format", value: "#{?#{&&:#{pane_active},#{>:#{window_panes},1}},#[bold fg=#1e1530 bg=#6a4b9c] ACTIVE #[default],}"},

--- a/cmd/tmux_manager_test.go
+++ b/cmd/tmux_manager_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseBoolArg(t *testing.T) {
 	if !parseBoolArg([]string{"--worktree", "/tmp/wt.1", "--force-unlock"}, "--force-unlock") {
@@ -61,6 +64,7 @@ func TestWTXPaneStyleOptions(t *testing.T) {
 	expected := map[string]string{
 		"pane-border-style":        "fg=#1e1530",
 		"pane-active-border-style": "fg=#6a4b9c",
+		"mode-style":               "fg=#1e1530,bg=#6a4b9c",
 		"pane-border-lines":        "heavy",
 		"pane-border-status":       "off",
 		"pane-border-format":       "#{?#{&&:#{pane_active},#{>:#{window_panes},1}},#[bold fg=#1e1530 bg=#6a4b9c] ACTIVE #[default],}",
@@ -96,5 +100,59 @@ func TestShouldDisableTmuxInputEnhancements(t *testing.T) {
 				t.Fatalf("shouldDisableTmuxInputEnhancements(%q)=%v, want %v", tt.term, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTmuxStatusRightHintIncludesScrollShortcut(t *testing.T) {
+	if !strings.Contains(tmuxStatusRightHint, "⌥[ scroll") {
+		t.Fatalf("expected status hint to include copy-mode shortcut, got %q", tmuxStatusRightHint)
+	}
+}
+
+func TestTmuxMouseBindings(t *testing.T) {
+	bindings := tmuxMouseBindings("wtx_s47")
+	if len(bindings) == 0 {
+		t.Fatalf("expected mouse bindings")
+	}
+
+	byKey := map[string]tmuxBinding{}
+	for _, binding := range bindings {
+		byKey[binding.key] = binding
+	}
+
+	for _, key := range []string{"MouseDown1Pane", "MouseDown1Border", "MouseDrag1Border", "WheelUpPane", "WheelDownPane", "M-["} {
+		if _, ok := byKey[key]; !ok {
+			t.Fatalf("expected binding for %q", key)
+		}
+	}
+
+	if got := strings.Join(byKey["WheelUpPane"].args, " "); !strings.Contains(got, "select-pane -t=; copy-mode -e; send-keys -X -N 1 scroll-up") {
+		t.Fatalf("expected WheelUpPane to select hovered pane, enter copy-mode, and scroll up, got %q", got)
+	}
+	if got := strings.Join(byKey["WheelUpPane"].args, " "); !strings.Contains(got, "#{||:#{alternate_on},#{mouse_any_flag}}") {
+		t.Fatalf("expected WheelUpPane to include alternate/mouse capture condition, got %q", got)
+	}
+
+	if !byKey["WheelUpPane"].repeatable {
+		t.Fatalf("expected WheelUpPane binding to be repeatable")
+	}
+	if !byKey["WheelDownPane"].repeatable {
+		t.Fatalf("expected WheelDownPane binding to be repeatable")
+	}
+}
+
+func TestTmuxMouseBindingsCopyModeTable(t *testing.T) {
+	bindings := tmuxMouseBindings("copy-mode-vi")
+	byKey := map[string]tmuxBinding{}
+	for _, binding := range bindings {
+		byKey[binding.key] = binding
+	}
+
+	up, ok := byKey["WheelUpPane"]
+	if !ok {
+		t.Fatalf("expected WheelUpPane in copy-mode table")
+	}
+	if got := strings.Join(up.args, " "); !strings.Contains(got, "send-keys -X -N 1 scroll-up") {
+		t.Fatalf("expected copy-mode wheel up to scroll by one line, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- fix tmux wheel-up/down behavior so scroll works reliably without requiring an initial click
- bind mouse wheel handling across wtx/root/copy-mode tables with deterministic scroll commands
- keep pane selection and border resize mouse bindings in sync
- set tmux mode-style to the wtx purple palette so copy/scroll indicator is no longer green
- add/update unit tests for tmux status hint + mouse binding generation

## Validation
- make e2e
- go test ./cmd -run TestTmuxMouseBindings
