### PR TITLE
Fix tmux modified-key passthrough and checkout fetch freshness

### DIFF
--- a/cmd/tmux_manager.go
+++ b/cmd/tmux_manager.go
@@ -15,7 +15,7 @@ import (
 )
 
 const tmuxStatusIntervalSeconds = "10"
-const tmuxStatusRightHint = " ^A actions | ^W back | ⌥[ scroll#{?#{>:#{window_panes},1}, | ⌥⇧↑/⌥⇧↓ resize,} "
+const tmuxStatusRightHint = " ^A actions | ^W back#{?#{>:#{window_panes},1}, | ⌥⇧↑/⌥⇧↓ resize,} "
 
 func ensureFreshTmuxSession(args []string) (bool, error) {
 	if tmuxIntegrationDisabled() {
@@ -309,7 +309,7 @@ func setDynamicWorktreeStatus(worktreePath string) {
 	_ = exec.Command("tmux", "set-environment", "-t", sessionID, "WTX_WORKTREE_PATH", worktreePath).Run()
 	tmuxSetOption(sessionID, "@wtx_worktree_path", worktreePath)
 	tmuxSetOption(sessionID, "status-left", " "+cmd+" ")
-	tmuxSetOption(sessionID, "status-right", " ^A actions | ^S split | ^P PR | ^L IDE | ⌥[ scroll#{?#{>:#{window_panes},1}, | ⌥↑/⌥↓ move | ⌥⇧↑/⌥⇧↓ resize,} ")
+	tmuxSetOption(sessionID, "status-right", " ^A actions | ^S split | ^P PR | ^L IDE#{?#{>:#{window_panes},1}, | ⌥↑/⌥↓ move | ⌥⇧↑/⌥⇧↓ resize,} ")
 	tmuxSetOption(sessionID, "status-right-length", "132")
 	titleCmd := "#(" + shellQuote(bin) + " tmux-title --worktree " + shellQuote(worktreePath) + ")"
 	tmuxSetOption(sessionID, "set-titles", "on")
@@ -460,7 +460,6 @@ func tmuxMouseBindings(table string) []tmuxBinding {
 			},
 			repeatable: true,
 		},
-		{key: "M-[", args: []string{"copy-mode", "-e"}},
 	}
 }
 

--- a/cmd/tmux_manager_test.go
+++ b/cmd/tmux_manager_test.go
@@ -103,9 +103,9 @@ func TestShouldDisableTmuxInputEnhancements(t *testing.T) {
 	}
 }
 
-func TestTmuxStatusRightHintIncludesScrollShortcut(t *testing.T) {
-	if !strings.Contains(tmuxStatusRightHint, "⌥[ scroll") {
-		t.Fatalf("expected status hint to include copy-mode shortcut, got %q", tmuxStatusRightHint)
+func TestTmuxStatusRightHintDoesNotIncludeScrollShortcut(t *testing.T) {
+	if strings.Contains(tmuxStatusRightHint, "⌥[ scroll") {
+		t.Fatalf("expected status hint to avoid alt+[ shortcut, got %q", tmuxStatusRightHint)
 	}
 }
 
@@ -120,10 +120,13 @@ func TestTmuxMouseBindings(t *testing.T) {
 		byKey[binding.key] = binding
 	}
 
-	for _, key := range []string{"MouseDown1Pane", "MouseDown1Border", "MouseDrag1Border", "WheelUpPane", "WheelDownPane", "M-["} {
+	for _, key := range []string{"MouseDown1Pane", "MouseDown1Border", "MouseDrag1Border", "WheelUpPane", "WheelDownPane"} {
 		if _, ok := byKey[key]; !ok {
 			t.Fatalf("expected binding for %q", key)
 		}
+	}
+	if _, ok := byKey["M-["]; ok {
+		t.Fatalf("did not expect M-[ binding because it can conflict with CSI modified keys")
 	}
 
 	if got := strings.Join(byKey["WheelUpPane"].args, " "); !strings.Contains(got, "select-pane -t=; copy-mode -e; send-keys -X -N 1 scroll-up") {

--- a/cmd/worktree_manager.go
+++ b/cmd/worktree_manager.go
@@ -305,17 +305,19 @@ func (m *WorktreeManager) FetchRepoBaseRef(baseRef string) error {
 		return err
 	}
 
-	resolved := baseRefForWorktreeAdd(repoRoot, gitPath, baseRef)
-	if _, err := gitOutputInDir(repoRoot, gitPath, "rev-parse", "--verify", resolved+"^{commit}"); err == nil {
-		return nil
-	}
-
 	remotes, err := listGitRemotes(repoRoot, gitPath)
 	if err != nil {
 		return err
 	}
 	if len(remotes) == 0 {
 		return nil
+	}
+	explicitRemote := isExplicitRemoteBaseRef(baseRef, remotes)
+	if !explicitRemote {
+		resolved := baseRefForWorktreeAdd(repoRoot, gitPath, baseRef)
+		if _, err := gitOutputInDir(repoRoot, gitPath, "rev-parse", "--verify", resolved+"^{commit}"); err == nil {
+			return nil
+		}
 	}
 
 	remote := preferredRemoteName(repoRoot, gitPath)
@@ -582,6 +584,26 @@ func fetchRemoteAndRefForBaseRef(baseRef string, remotes []string, preferredRemo
 		return "", "", false
 	}
 	return preferredRemote, baseRef, true
+}
+
+func isExplicitRemoteBaseRef(baseRef string, remotes []string) bool {
+	baseRef = strings.TrimSpace(baseRef)
+	if baseRef == "" {
+		return false
+	}
+	for _, remote := range remotes {
+		remote = strings.TrimSpace(remote)
+		if remote == "" {
+			continue
+		}
+		if strings.HasPrefix(baseRef, remote+"/") {
+			return true
+		}
+		if strings.HasPrefix(baseRef, "refs/remotes/"+remote+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func listGitRemotes(repoRoot string, gitPath string) ([]string, error) {

--- a/cmd/worktree_manager_test.go
+++ b/cmd/worktree_manager_test.go
@@ -127,3 +127,29 @@ func TestFetchRemoteAndRefForBaseRef(t *testing.T) {
 		})
 	}
 }
+
+func TestIsExplicitRemoteBaseRef(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		baseRef string
+		remotes []string
+		want    bool
+	}{
+		{name: "remote short form", baseRef: "origin/main", remotes: []string{"origin"}, want: true},
+		{name: "remote refs form", baseRef: "refs/remotes/origin/main", remotes: []string{"origin"}, want: true},
+		{name: "other remote", baseRef: "upstream/main", remotes: []string{"origin", "upstream"}, want: true},
+		{name: "local branch", baseRef: "main", remotes: []string{"origin"}, want: false},
+		{name: "head", baseRef: "HEAD", remotes: []string{"origin"}, want: false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isExplicitRemoteBaseRef(tc.baseRef, tc.remotes)
+			if got != tc.want {
+				t.Fatalf("isExplicitRemoteBaseRef(%q)=%v, want %v", tc.baseRef, got, tc.want)
+			}
+		})
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -509,6 +509,61 @@ func TestE2ECheckoutNewBranchWithFetchOnIsolatedRepo(t *testing.T) {
 	runCmd(t, clone, nil, "git", "show-ref", "--verify", "refs/heads/"+branch)
 }
 
+func TestE2ECheckoutNewBranchWithFetchUpdatesStaleOriginBase(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	originBare := filepath.Join(root, "origin.git")
+	seed := filepath.Join(root, "seed")
+	clone := filepath.Join(root, "clone")
+
+	runCmd(t, root, nil, "git", "init", "--bare", originBare)
+	runCmd(t, root, nil, "git", "init", seed)
+	runCmd(t, seed, nil, "git", "checkout", "-B", "main")
+	runCmd(t, seed, nil, "git", "config", "user.email", "e2e@example.test")
+	runCmd(t, seed, nil, "git", "config", "user.name", "WTX E2E")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("seed v1\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runCmd(t, seed, nil, "git", "add", "README.md")
+	runCmd(t, seed, nil, "git", "commit", "-m", "init main")
+	runCmd(t, seed, nil, "git", "remote", "add", "origin", originBare)
+	runCmd(t, seed, nil, "git", "push", "-u", "origin", "main")
+
+	runCmd(t, root, nil, "git", "clone", originBare, clone)
+	runCmd(t, clone, nil, "git", "config", "user.email", "e2e@example.test")
+	runCmd(t, clone, nil, "git", "config", "user.name", "WTX E2E")
+
+	// Advance origin/main after clone so clone's origin/main is stale until fetch.
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("seed v2\n"), 0o644); err != nil {
+		t.Fatalf("update seed file: %v", err)
+	}
+	runCmd(t, seed, nil, "git", "add", "README.md")
+	runCmd(t, seed, nil, "git", "commit", "-m", "advance main")
+	runCmd(t, seed, nil, "git", "push", "origin", "main")
+	latestMain := runCmd(t, seed, nil, "git", "rev-parse", "main")
+
+	managedRoot := clone + ".wt"
+	managedWorktree := filepath.Join(managedRoot, "wt.1")
+	if err := os.MkdirAll(managedRoot, 0o755); err != nil {
+		t.Fatalf("mkdir managed root: %v", err)
+	}
+	runCmd(t, clone, nil, "git", "worktree", "add", "-b", "slot/one", managedWorktree, "main")
+
+	home := t.TempDir()
+	writeConfig(t, home, "true")
+	env := testEnv(home)
+	branch := "feature/fetch-stale-origin-main"
+	result := runWTX(t, clone, env, "checkout", "-b", branch, "--from", "origin/main", "--fetch")
+	if result.err != nil {
+		t.Fatalf("e2e checkout failed: %v\n%s", result.err, result.out)
+	}
+
+	gotHead := runCmd(t, clone, nil, "git", "rev-parse", "refs/heads/"+branch)
+	if gotHead != latestMain {
+		t.Fatalf("expected new branch to start from fetched origin/main tip %q, got %q", latestMain, gotHead)
+	}
+}
+
 func TestE2ECreateBranchFailsOnUnbornHeadWithActionableError(t *testing.T) {
 	t.Parallel()
 	repo := filepath.Join(t.TempDir(), "unborn")


### PR DESCRIPTION
Summary:
- remove tmux alt-left-bracket binding that could intercept CSI-prefixed modified keys before they reach coding agents
- remove the alt-left-bracket scroll hint from tmux status text
- ensure explicit remote base refs like origin/main always fetch during checkout create flow, even when locally resolvable

Tests:
- go test ./cmd
- go test ./e2e -run TestE2ECheckoutNewBranchWithFetchUpdatesStaleOriginBase
- make e2e