### PR TITLE
Fix intermittent Shift+Enter in new tmux sessions

### DIFF
--- a/cmd/tmux_manager.go
+++ b/cmd/tmux_manager.go
@@ -64,6 +64,9 @@ func ensureFreshTmuxSession(args []string) (bool, error) {
 
 	applyStartupThemeToSession(session, cwd, parentTerminal)
 	if inTmux {
+		// Apply defaults before launching the pane command so modified-key handling is
+		// active from the first prompt in the new session.
+		applyWTXSessionDefaults(session, false)
 		if err := launchCommandInSession(session, bin, args[1:]); err != nil {
 			return false, err
 		}
@@ -384,6 +387,7 @@ func applyWTXSessionDefaults(sessionID string, enableDestroyUnattached bool) {
 	configureTmuxStatusRefreshHooks(sessionID)
 	configureTmuxPaneBadgeBehavior(sessionID)
 	configureTmuxMouseBindings(keyTable)
+	clearLegacyTmuxInputBindings(keyTable)
 
 	// Only resize when split panes are present.
 	_ = exec.Command("tmux", "bind-key", "-r", "-T", keyTable, "M-Up", "if-shell", "-F", "#{>:#{window_panes},1}", "select-pane -U").Run()
@@ -401,6 +405,16 @@ func applyWTXSessionDefaults(sessionID string, enableDestroyUnattached bool) {
 	}
 
 	configureTmuxActionBindings(sessionID, resolveAgentLifecycleBinary())
+}
+
+func clearLegacyTmuxInputBindings(keyTable string) {
+	tables := []string{"root", "copy-mode", "copy-mode-vi"}
+	if keyTable = strings.TrimSpace(keyTable); keyTable != "" {
+		tables = append(tables, keyTable)
+	}
+	for _, table := range tables {
+		_ = exec.Command("tmux", "unbind-key", "-T", table, "M-[").Run()
+	}
 }
 
 func configureTmuxMouseBindings(keyTable string) {


### PR DESCRIPTION
## Summary
- apply tmux session defaults before launching the pane command in the in-tmux path so extkey handling is active from the first prompt
- keep post-switch re-apply of defaults
- proactively unbind legacy M-[ across key tables during defaults apply to avoid escape-sequence interception

## Root cause
A startup ordering issue in ensureFreshTmuxSession launched the command before key handling options (xterm-keys, extended-keys) were guaranteed to be active in the new session, causing intermittent modified-enter behavior.

## Testing
- make e2e
- GOCACHE=/tmp/wtx-go-cache go test ./cmd
