### PR TITLE
Fix Ctrl+P no-PR fallback and draft GH status

### DIFF
--- a/cmd/gh_manager.go
+++ b/cmd/gh_manager.go
@@ -572,6 +572,9 @@ func computePRStatus(state string, mergedAt string, isDraft bool, mergeStateStat
 	if hasConflictPRStatus(mergeStateStatus) {
 		return "conflict"
 	}
+	if base == "draft" {
+		return "draft"
+	}
 	ciPassed := ciState == PRCISuccess
 	commentsResolved := commentsKnown && unresolvedComments <= 0
 	reviewReady := !reviewRequired || reviewSatisfied
@@ -588,9 +591,6 @@ func computePRStatus(state string, mergedAt string, isDraft bool, mergeStateStat
 	}
 	if commentsRequired && commentsKnown && unresolvedComments > 0 {
 		return "awaiting-comments"
-	}
-	if base == "draft" {
-		return "draft"
 	}
 	if base == "open" {
 		return "open"

--- a/cmd/gh_manager_test.go
+++ b/cmd/gh_manager_test.go
@@ -48,6 +48,7 @@ func TestComputePRStatus_Priority(t *testing.T) {
 		{name: "review not required", state: "OPEN", reviewOK: false, reviewReq: false, ci: PRCISuccess, ciReq: true, unres: 0, known: true, commentsReq: true, want: "can-merge"},
 		{name: "ci not required", state: "OPEN", reviewOK: true, reviewReq: true, ci: PRCIInProgress, ciReq: false, unres: 0, known: true, commentsReq: true, want: "can-merge"},
 		{name: "comments not required", state: "OPEN", reviewOK: true, reviewReq: true, ci: PRCISuccess, ciReq: true, unres: 2, known: true, commentsReq: false, want: "can-merge"},
+		{name: "draft never can-merge", state: "OPEN", isDraft: true, reviewOK: true, reviewReq: true, ci: PRCISuccess, ciReq: true, unres: 0, known: true, commentsReq: true, want: "draft"},
 		{name: "draft fallback", state: "OPEN", isDraft: true, reviewOK: true, reviewReq: true, ci: PRCISuccess, ciReq: true, unres: 2, known: false, commentsReq: true, want: "draft"},
 		{name: "open fallback", state: "OPEN", reviewOK: true, reviewReq: true, ci: PRCISuccess, ciReq: true, unres: 2, known: false, commentsReq: true, want: "open"},
 	}

--- a/cmd/tmux_actions_popup.go
+++ b/cmd/tmux_actions_popup.go
@@ -389,6 +389,15 @@ func runTmuxAction(basePath string, sourcePane string, action tmuxAction, rename
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			msg := commandErrorMessage(err, out)
+			if isNoPRForCurrentBranchMessage(msg) {
+				fallback := exec.Command("gh", "pr", "list", "--state", "open", "--author", "@me", "--web")
+				fallback.Dir = basePath
+				fallbackOut, fallbackErr := fallback.CombinedOutput()
+				if fallbackErr == nil {
+					return nil
+				}
+				msg = commandErrorMessage(fallbackErr, fallbackOut)
+			}
 			if showTmuxActionErrorMessage(msg) {
 				return nil
 			}
@@ -721,6 +730,11 @@ func normalizeTmuxDisplayMessage(message string) string {
 		return message
 	}
 	return message[:maxLen-3] + "..."
+}
+
+func isNoPRForCurrentBranchMessage(message string) bool {
+	normalized := strings.ToLower(normalizeTmuxDisplayMessage(message))
+	return strings.Contains(normalized, "no pull requests found for branch")
 }
 
 func tmuxActionsPopupCommand(wtxBin string) string {

--- a/cmd/tmux_actions_popup_test.go
+++ b/cmd/tmux_actions_popup_test.go
@@ -281,6 +281,24 @@ func TestNormalizeTmuxDisplayMessage(t *testing.T) {
 	}
 }
 
+func TestIsNoPRForCurrentBranchMessage(t *testing.T) {
+	if !isNoPRForCurrentBranchMessage("no pull requests found for branch \"feature/x\"") {
+		t.Fatalf("expected no-PR message to be recognized")
+	}
+	if !isNoPRForCurrentBranchMessage("No Pull Requests Found\nfor Branch \"feature/x\"") {
+		t.Fatalf("expected no-PR message with mixed case/newline to be recognized")
+	}
+}
+
+func TestIsNoPRForCurrentBranchMessage_FalseForOtherErrors(t *testing.T) {
+	if isNoPRForCurrentBranchMessage("pull request not found") {
+		t.Fatalf("expected non-branch no-PR error to be ignored")
+	}
+	if isNoPRForCurrentBranchMessage("exit status 1") {
+		t.Fatalf("expected unrelated errors to be ignored")
+	}
+}
+
 func TestTmuxActionsCommandWithAction_InjectsSourcePane(t *testing.T) {
 	got := tmuxActionsCommandWithAction("/usr/local/bin/wtx", tmuxActionBack)
 	if strings.Contains(got, "--source-pane") {


### PR DESCRIPTION
## Summary
- make Ctrl+P PR action fall back to opening GitHub PR list filtered to open PRs by current author when no PR exists for the current branch
- ensure draft PRs never surface as GH mergeable in status labels
- add targeted regression tests for no-PR message detection and draft status priority

## Validation
- GOCACHE=/tmp/go-build go test ./cmd
- make e2e