### PR TITLE
Allow unclean branch selection and optimize open-screen branch search

### DIFF
--- a/cmd/open_screen.go
+++ b/cmd/open_screen.go
@@ -64,7 +64,8 @@ func loadOpenScreenCmd(orchestrator *WorktreeOrchestrator, mgr *WorktreeManager)
 		}
 
 		slots := make([]openSlotState, len(status.Worktrees))
-		lockedBranches := make(map[string]bool, len(status.Worktrees))
+		lockedOnlyBranches := make(map[string]bool, len(status.Worktrees))
+		openSlotBranches := make(map[string]bool, len(status.Worktrees))
 		seenPR := make(map[string]bool, len(branches)+len(status.Worktrees))
 		prBranches := make([]string, 0, len(branches)+len(status.Worktrees))
 
@@ -75,25 +76,34 @@ func loadOpenScreenCmd(orchestrator *WorktreeOrchestrator, mgr *WorktreeManager)
 				Locked:    !wt.Available,
 				PRLoading: true,
 			}
-			if slots[i].Locked {
-				lockedBranches[strings.TrimSpace(slots[i].Branch)] = true
-			}
 			name := strings.TrimSpace(slots[i].Branch)
-			if name != "" && name != "detached" && !seenPR[name] {
+			if name == "" {
+				continue
+			}
+			if slots[i].Locked {
+				if !openSlotBranches[name] {
+					lockedOnlyBranches[name] = true
+				}
+			} else {
+				openSlotBranches[name] = true
+				delete(lockedOnlyBranches, name)
+			}
+			if name != "detached" && !seenPR[name] {
 				seenPR[name] = true
 				prBranches = append(prBranches, name)
 			}
 		}
 
 		openBranches := make([]openBranchOption, 0, len(branches))
-		lockedList := make([]openBranchOption, 0, len(lockedBranches))
-		lockedSeen := make(map[string]bool, len(lockedBranches))
+		lockedList := make([]openBranchOption, 0, len(lockedOnlyBranches))
+		lockedSeen := make(map[string]bool, len(lockedOnlyBranches))
+		openSeen := make(map[string]bool, len(branches)+len(openSlotBranches))
 		for _, branch := range branches {
 			name := strings.TrimSpace(branch)
 			if name == "" {
 				continue
 			}
-			if lockedBranches[name] {
+			if lockedOnlyBranches[name] {
 				lockedList = append(lockedList, openBranchOption{
 					Name:      name,
 					PRLoading: true,
@@ -109,13 +119,14 @@ func loadOpenScreenCmd(orchestrator *WorktreeOrchestrator, mgr *WorktreeManager)
 				Name:      name,
 				PRLoading: true,
 			})
+			openSeen[name] = true
 			if !seenPR[name] {
 				seenPR[name] = true
 				prBranches = append(prBranches, name)
 			}
 		}
-		missingLocked := make([]string, 0, len(lockedBranches))
-		for name := range lockedBranches {
+		missingLocked := make([]string, 0, len(lockedOnlyBranches))
+		for name := range lockedOnlyBranches {
 			if !lockedSeen[name] {
 				missingLocked = append(missingLocked, name)
 			}
@@ -123,6 +134,23 @@ func loadOpenScreenCmd(orchestrator *WorktreeOrchestrator, mgr *WorktreeManager)
 		sort.Strings(missingLocked)
 		for _, name := range missingLocked {
 			lockedList = append(lockedList, openBranchOption{
+				Name:      name,
+				PRLoading: true,
+			})
+			if !seenPR[name] {
+				seenPR[name] = true
+				prBranches = append(prBranches, name)
+			}
+		}
+		missingOpen := make([]string, 0, len(openSlotBranches))
+		for name := range openSlotBranches {
+			if !openSeen[name] {
+				missingOpen = append(missingOpen, name)
+			}
+		}
+		sort.Strings(missingOpen)
+		for _, name := range missingOpen {
+			openBranches = append(openBranches, openBranchOption{
 				Name:      name,
 				PRLoading: true,
 			})

--- a/cmd/open_screen.go
+++ b/cmd/open_screen.go
@@ -49,6 +49,14 @@ type openScreenDirtyMsg struct {
 	dirtyByPath map[string]bool
 }
 
+type openAllBranchesLoadedMsg struct {
+	branches       []openBranchOption
+	lockedBranches []openBranchOption
+	err            error
+}
+
+const openSearchMatchLimit = 200
+
 func loadOpenScreenCmd(orchestrator *WorktreeOrchestrator, mgr *WorktreeManager) tea.Cmd {
 	return func() tea.Msg {
 		if orchestrator == nil || mgr == nil {
@@ -64,11 +72,6 @@ func loadOpenScreenCmd(orchestrator *WorktreeOrchestrator, mgr *WorktreeManager)
 		}
 
 		slots := make([]openSlotState, len(status.Worktrees))
-		lockedOnlyBranches := make(map[string]bool, len(status.Worktrees))
-		openSlotBranches := make(map[string]bool, len(status.Worktrees))
-		seenPR := make(map[string]bool, len(branches)+len(status.Worktrees))
-		prBranches := make([]string, 0, len(branches)+len(status.Worktrees))
-
 		for i, wt := range status.Worktrees {
 			slots[i] = openSlotState{
 				Path:      wt.Path,
@@ -76,89 +79,8 @@ func loadOpenScreenCmd(orchestrator *WorktreeOrchestrator, mgr *WorktreeManager)
 				Locked:    !wt.Available,
 				PRLoading: true,
 			}
-			name := strings.TrimSpace(slots[i].Branch)
-			if name == "" {
-				continue
-			}
-			if slots[i].Locked {
-				if !openSlotBranches[name] {
-					lockedOnlyBranches[name] = true
-				}
-			} else {
-				openSlotBranches[name] = true
-				delete(lockedOnlyBranches, name)
-			}
-			if name != "detached" && !seenPR[name] {
-				seenPR[name] = true
-				prBranches = append(prBranches, name)
-			}
 		}
-
-		openBranches := make([]openBranchOption, 0, len(branches))
-		lockedList := make([]openBranchOption, 0, len(lockedOnlyBranches))
-		lockedSeen := make(map[string]bool, len(lockedOnlyBranches))
-		openSeen := make(map[string]bool, len(branches)+len(openSlotBranches))
-		for _, branch := range branches {
-			name := strings.TrimSpace(branch)
-			if name == "" {
-				continue
-			}
-			if lockedOnlyBranches[name] {
-				lockedList = append(lockedList, openBranchOption{
-					Name:      name,
-					PRLoading: true,
-				})
-				lockedSeen[name] = true
-				if !seenPR[name] {
-					seenPR[name] = true
-					prBranches = append(prBranches, name)
-				}
-				continue
-			}
-			openBranches = append(openBranches, openBranchOption{
-				Name:      name,
-				PRLoading: true,
-			})
-			openSeen[name] = true
-			if !seenPR[name] {
-				seenPR[name] = true
-				prBranches = append(prBranches, name)
-			}
-		}
-		missingLocked := make([]string, 0, len(lockedOnlyBranches))
-		for name := range lockedOnlyBranches {
-			if !lockedSeen[name] {
-				missingLocked = append(missingLocked, name)
-			}
-		}
-		sort.Strings(missingLocked)
-		for _, name := range missingLocked {
-			lockedList = append(lockedList, openBranchOption{
-				Name:      name,
-				PRLoading: true,
-			})
-			if !seenPR[name] {
-				seenPR[name] = true
-				prBranches = append(prBranches, name)
-			}
-		}
-		missingOpen := make([]string, 0, len(openSlotBranches))
-		for name := range openSlotBranches {
-			if !openSeen[name] {
-				missingOpen = append(missingOpen, name)
-			}
-		}
-		sort.Strings(missingOpen)
-		for _, name := range missingOpen {
-			openBranches = append(openBranches, openBranchOption{
-				Name:      name,
-				PRLoading: true,
-			})
-			if !seenPR[name] {
-				seenPR[name] = true
-				prBranches = append(prBranches, name)
-			}
-		}
+		openBranches, lockedList, prBranches := buildOpenBranchLists(branches, slots, true)
 
 		return openScreenLoadedMsg{
 			status:         status,
@@ -169,6 +91,107 @@ func loadOpenScreenCmd(orchestrator *WorktreeOrchestrator, mgr *WorktreeManager)
 			fetchID:        fmt.Sprintf("%d", time.Now().UnixNano()),
 		}
 	}
+}
+
+func loadAllOpenBranchesCmd(mgr *WorktreeManager, slots []openSlotState) tea.Cmd {
+	return func() tea.Msg {
+		if mgr == nil {
+			return openAllBranchesLoadedMsg{err: fmt.Errorf("open screen unavailable")}
+		}
+		branches, err := mgr.ListAllLocalBranchesByRecentUse()
+		if err != nil {
+			return openAllBranchesLoadedMsg{err: err}
+		}
+		openBranches, lockedBranches, _ := buildOpenBranchLists(branches, slots, false)
+		return openAllBranchesLoadedMsg{
+			branches:       openBranches,
+			lockedBranches: lockedBranches,
+		}
+	}
+}
+
+func buildOpenBranchLists(branches []string, slots []openSlotState, prLoading bool) ([]openBranchOption, []openBranchOption, []string) {
+	lockedOnlyBranches := make(map[string]bool, len(slots))
+	openSlotBranches := make(map[string]bool, len(slots))
+	seenPR := make(map[string]bool, len(branches)+len(slots))
+	prBranches := make([]string, 0, len(branches)+len(slots))
+
+	for _, slot := range slots {
+		name := strings.TrimSpace(slot.Branch)
+		if name == "" {
+			continue
+		}
+		if slot.Locked {
+			if !openSlotBranches[name] {
+				lockedOnlyBranches[name] = true
+			}
+		} else {
+			openSlotBranches[name] = true
+			delete(lockedOnlyBranches, name)
+		}
+		if name != "detached" && !seenPR[name] {
+			seenPR[name] = true
+			prBranches = append(prBranches, name)
+		}
+	}
+
+	openBranches := make([]openBranchOption, 0, len(branches))
+	lockedList := make([]openBranchOption, 0, len(lockedOnlyBranches))
+	lockedSeen := make(map[string]bool, len(lockedOnlyBranches))
+	openSeen := make(map[string]bool, len(branches)+len(openSlotBranches))
+	for _, branch := range branches {
+		name := strings.TrimSpace(branch)
+		if name == "" {
+			continue
+		}
+		if lockedOnlyBranches[name] {
+			lockedList = append(lockedList, openBranchOption{Name: name, PRLoading: prLoading})
+			lockedSeen[name] = true
+			if !seenPR[name] {
+				seenPR[name] = true
+				prBranches = append(prBranches, name)
+			}
+			continue
+		}
+		openBranches = append(openBranches, openBranchOption{Name: name, PRLoading: prLoading})
+		openSeen[name] = true
+		if !seenPR[name] {
+			seenPR[name] = true
+			prBranches = append(prBranches, name)
+		}
+	}
+
+	missingLocked := make([]string, 0, len(lockedOnlyBranches))
+	for name := range lockedOnlyBranches {
+		if !lockedSeen[name] {
+			missingLocked = append(missingLocked, name)
+		}
+	}
+	sort.Strings(missingLocked)
+	for _, name := range missingLocked {
+		lockedList = append(lockedList, openBranchOption{Name: name, PRLoading: prLoading})
+		if !seenPR[name] {
+			seenPR[name] = true
+			prBranches = append(prBranches, name)
+		}
+	}
+
+	missingOpen := make([]string, 0, len(openSlotBranches))
+	for name := range openSlotBranches {
+		if !openSeen[name] {
+			missingOpen = append(missingOpen, name)
+		}
+	}
+	sort.Strings(missingOpen)
+	for _, name := range missingOpen {
+		openBranches = append(openBranches, openBranchOption{Name: name, PRLoading: prLoading})
+		if !seenPR[name] {
+			seenPR[name] = true
+			prBranches = append(prBranches, name)
+		}
+	}
+
+	return openBranches, lockedList, prBranches
 }
 
 func fetchDirtyStatusCmd(paths []string) tea.Cmd {
@@ -398,7 +421,8 @@ func renderOpenScreen(m model) string {
 	}
 	branchColWidth := openBranchColumnWidth(m.openBranches, m.openLockedBranches)
 	filtered := openFilteredIndices(m.openTypeahead, m.openBranches)
-	for _, branchIndex := range filtered {
+	visibleFiltered, trimmed := openVisibleFilteredIndices(filtered, m.openSelected, openBranchRenderLimit(m.height))
+	for _, branchIndex := range visibleFiltered {
 		branch := m.openBranches[branchIndex]
 		cursor := "  "
 		pr := "-"
@@ -416,6 +440,9 @@ func renderOpenScreen(m model) string {
 		} else {
 			b.WriteString(actionNormalStyle.Render(line) + "\n")
 		}
+	}
+	if trimmed {
+		b.WriteString(secondaryStyle.Render(fmt.Sprintf("  ... showing %d of %d matches", len(visibleFiltered), len(filtered))) + "\n")
 	}
 	if len(filtered) == 0 && len(m.openBranches) == 0 {
 		b.WriteString("  No local branches available.\n")
@@ -570,9 +597,59 @@ func openFilteredIndices(query string, branches []openBranchOption) []int {
 		}
 		if nameMatch || prMatch {
 			out = append(out, i)
+			if len(out) >= openSearchMatchLimit {
+				break
+			}
 		}
 	}
 	return out
+}
+
+func openBranchRenderLimit(height int) int {
+	if height <= 0 {
+		return 20
+	}
+	limit := height - 16
+	if limit < 8 {
+		limit = 8
+	}
+	if limit > 40 {
+		limit = 40
+	}
+	return limit
+}
+
+func openVisibleFilteredIndices(filtered []int, selectedRow int, limit int) ([]int, bool) {
+	if len(filtered) <= limit || limit <= 0 {
+		return filtered, false
+	}
+	if selectedRow <= 0 {
+		return filtered[:limit], true
+	}
+	selectedIndex := selectedRow - 1
+	pos := -1
+	for i, idx := range filtered {
+		if idx == selectedIndex {
+			pos = i
+			break
+		}
+	}
+	if pos < 0 {
+		return filtered[:limit], true
+	}
+	start := pos - limit/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + limit
+	if end > len(filtered) {
+		end = len(filtered)
+		start = end - limit
+		if start < 0 {
+			start = 0
+		}
+	}
+	return filtered[start:end], true
 }
 
 func moveOpenSelection(current int, delta int, filtered []int) int {

--- a/cmd/open_screen_test.go
+++ b/cmd/open_screen_test.go
@@ -71,3 +71,64 @@ func findRenderedLine(view string, needle string) string {
 	}
 	return ""
 }
+
+func TestOpenFilteredIndicesCapsSearchResults(t *testing.T) {
+	branches := make([]openBranchOption, 0, 500)
+	for i := 0; i < 500; i++ {
+		branches = append(branches, openBranchOption{Name: "feature/load-test"})
+	}
+	got := openFilteredIndices("feature", branches)
+	if len(got) != openSearchMatchLimit {
+		t.Fatalf("expected %d results, got %d", openSearchMatchLimit, len(got))
+	}
+}
+
+func TestBuildOpenBranchLists_NoPRLoadingInSearchMode(t *testing.T) {
+	openBranches, lockedBranches, _ := buildOpenBranchLists([]string{"main", "feature/a"}, nil, false)
+	for _, b := range openBranches {
+		if b.PRLoading {
+			t.Fatalf("expected open branch PRLoading=false for search mode")
+		}
+	}
+	for _, b := range lockedBranches {
+		if b.PRLoading {
+			t.Fatalf("expected locked branch PRLoading=false for search mode")
+		}
+	}
+}
+
+func TestOpenVisibleFilteredIndices_KeepsSelectionVisible(t *testing.T) {
+	filtered := make([]int, 0, 50)
+	for i := 0; i < 50; i++ {
+		filtered = append(filtered, i)
+	}
+	visible, trimmed := openVisibleFilteredIndices(filtered, 30, 10)
+	if !trimmed {
+		t.Fatalf("expected trimmed=true")
+	}
+	if len(visible) != 10 {
+		t.Fatalf("expected 10 visible entries, got %d", len(visible))
+	}
+	found := false
+	for _, idx := range visible {
+		if idx == 29 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected selected index to be visible")
+	}
+}
+
+func TestOpenBranchRenderLimit_Clamped(t *testing.T) {
+	if got := openBranchRenderLimit(0); got != 20 {
+		t.Fatalf("expected default limit 20, got %d", got)
+	}
+	if got := openBranchRenderLimit(200); got != 40 {
+		t.Fatalf("expected max-clamped limit 40, got %d", got)
+	}
+	if got := openBranchRenderLimit(12); got != 8 {
+		t.Fatalf("expected min-clamped limit 8, got %d", got)
+	}
+}

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -63,8 +63,14 @@ type model struct {
 	openSelected          int
 	openTypeahead         string
 	openTypeaheadAt       time.Time
+	openSearchAllActive   bool
 	openBranches          []openBranchOption
 	openLockedBranches    []openBranchOption
+	openRecentBranches    []openBranchOption
+	openRecentLocked      []openBranchOption
+	openAllBranches       []openBranchOption
+	openAllLocked         []openBranchOption
+	openAllLoaded         bool
 	openSlots             []openSlotState
 	openPRBranches        []string
 	openFetchID           string
@@ -225,11 +231,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.openLoading = false
 			m.openBranches = nil
+			m.openRecentBranches = nil
 			m.openSlots = nil
 			m.openPRBranches = nil
 			m.openLoadErr = msg.err.Error()
 			return m, nil
 		}
+		m.openSearchAllActive = false
+		m.openAllLoaded = false
+		m.openAllBranches = nil
+		m.openAllLocked = nil
+		m.openRecentBranches = msg.branches
+		m.openRecentLocked = msg.lockedBranches
 		m.openBranches = msg.branches
 		m.openLockedBranches = msg.lockedBranches
 		m.openSlots = msg.slots
@@ -266,6 +279,28 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		cmds = append(cmds, fetchOpenPRDataCmd(m.orchestrator, m.status.RepoRoot, m.openPRBranches, msg.fetchID))
 		return m, tea.Batch(cmds...)
+	case openAllBranchesLoadedMsg:
+		if msg.err != nil {
+			if strings.TrimSpace(m.openTypeahead) != "" {
+				m.openLoadErr = msg.err.Error()
+			}
+			return m, nil
+		}
+		m.openAllLoaded = true
+		m.openAllBranches = msg.branches
+		m.openAllLocked = msg.lockedBranches
+		if strings.TrimSpace(m.openTypeahead) != "" {
+			m.openSearchAllActive = true
+			m.openBranches = m.openAllBranches
+			m.openLockedBranches = m.openAllLocked
+			filtered := openFilteredIndices(m.openTypeahead, m.openBranches)
+			m.openSelected = ensureOpenSelectionVisible(m.openSelected, filtered)
+			if m.openSelected == 0 && len(filtered) > 0 {
+				m.openSelected = filtered[0] + 1
+			}
+			m.openLoadErr = ""
+		}
+		return m, nil
 	case openScreenPRDataMsg:
 		if strings.TrimSpace(msg.fetchID) == "" || msg.fetchID != m.openFetchID {
 			return m, nil
@@ -276,7 +311,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.openLoadErr = ""
+		if m.openSearchAllActive {
+			applyPRDataToOpenState(nil, nil, &m.openSlots, msg.byBranch)
+			return m, nil
+		}
 		applyPRDataToOpenState(&m.openBranches, &m.openLockedBranches, &m.openSlots, msg.byBranch)
+		m.openRecentBranches = m.openBranches
+		m.openRecentLocked = m.openLockedBranches
 		return m, nil
 	case openScreenDirtyMsg:
 		for i := range m.openSlots {
@@ -699,6 +740,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.openTypeahead += queryPart
 				}
 				m.openTypeaheadAt = now
+				if strings.TrimSpace(m.openTypeahead) != "" {
+					if m.openAllLoaded {
+						m.openSearchAllActive = true
+						m.openBranches = m.openAllBranches
+						m.openLockedBranches = m.openAllLocked
+					} else {
+						filtered := openFilteredIndices(m.openTypeahead, m.openBranches)
+						m.openSelected = ensureOpenSelectionVisible(m.openSelected, filtered)
+						if m.openSelected == 0 && len(filtered) > 0 {
+							m.openSelected = filtered[0] + 1
+						}
+						m.errMsg = ""
+						return m, loadAllOpenBranchesCmd(m.mgr, m.openSlots)
+					}
+				}
 				filtered := openFilteredIndices(m.openTypeahead, m.openBranches)
 				m.openSelected = ensureOpenSelectionVisible(m.openSelected, filtered)
 				if m.openSelected == 0 && len(filtered) > 0 {
@@ -717,6 +773,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.openTypeahead = string(r[:len(r)-1])
 				}
 				m.openTypeaheadAt = time.Now()
+				if strings.TrimSpace(m.openTypeahead) == "" {
+					m.openSearchAllActive = false
+					m.openBranches = m.openRecentBranches
+					m.openLockedBranches = m.openRecentLocked
+				} else if m.openAllLoaded {
+					m.openSearchAllActive = true
+					m.openBranches = m.openAllBranches
+					m.openLockedBranches = m.openAllLocked
+				}
 				filtered := openFilteredIndices(m.openTypeahead, m.openBranches)
 				m.openSelected = ensureOpenSelectionVisible(m.openSelected, filtered)
 				if strings.TrimSpace(m.openTypeahead) != "" && m.openSelected == 0 && len(filtered) > 0 {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -623,7 +623,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						)
 						return m, m.confirmForm.Init()
 					}
-					if slot.Dirty {
+					if slot.Dirty && strings.TrimSpace(slot.Branch) != strings.TrimSpace(m.openTargetBranch) {
 						m.warnMsg = "Worktree is unclean. Clean it first."
 						m.pendingPath = slot.Path
 						m.pendingBranch = slot.Branch

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -192,3 +192,53 @@ func TestOpenPickAllowsDirtyWorktreeWhenBranchMatchesTarget(t *testing.T) {
 		t.Fatalf("expected command to be scheduled")
 	}
 }
+
+func TestOpenScreenSearchLoadsAllBranchesOnFirstType(t *testing.T) {
+	m := newModel()
+	m.mode = modeOpen
+	m.openStage = openStageMain
+	m.openRecentBranches = []openBranchOption{{Name: "recent/one"}}
+	m.openRecentLocked = []openBranchOption{}
+	m.openBranches = append([]openBranchOption{}, m.openRecentBranches...)
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	updated := updatedModel.(model)
+	if updated.openTypeahead != "f" {
+		t.Fatalf("expected typeahead to be updated, got %q", updated.openTypeahead)
+	}
+	if cmd == nil {
+		t.Fatalf("expected loading-all-branches command on first search input")
+	}
+
+	updatedModel, _ = updated.Update(openAllBranchesLoadedMsg{
+		branches:       []openBranchOption{{Name: "feature/a"}, {Name: "feature/b"}},
+		lockedBranches: []openBranchOption{{Name: "locked/x"}},
+	})
+	updated = updatedModel.(model)
+	if !updated.openSearchAllActive {
+		t.Fatalf("expected search-all mode to activate after all branches load")
+	}
+	if len(updated.openBranches) != 2 {
+		t.Fatalf("expected all-branch list to be active, got %d entries", len(updated.openBranches))
+	}
+}
+
+func TestOpenScreenPRDataIgnoredForSearchAllBranchList(t *testing.T) {
+	m := newModel()
+	m.mode = modeOpen
+	m.openSearchAllActive = true
+	m.openFetchID = "fetch-1"
+	m.openBranches = []openBranchOption{{Name: "feature/a", PRLoading: false}}
+	m.openSlots = []openSlotState{{Branch: "feature/a"}}
+
+	updatedModel, _ := m.Update(openScreenPRDataMsg{
+		fetchID: "fetch-1",
+		byBranch: map[string]PRData{
+			"feature/a": {Number: 42, URL: "https://example.test/pr/42"},
+		},
+	})
+	updated := updatedModel.(model)
+	if updated.openBranches[0].HasPR {
+		t.Fatalf("expected search-all branch rows to remain without PR data")
+	}
+}

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -169,3 +169,26 @@ func TestOpenScreenKeepsPreviousLoadErrorUntilPRDataResolves(t *testing.T) {
 		t.Fatalf("expected load error to clear after successful PR fetch, got %q", updated.openLoadErr)
 	}
 }
+
+func TestOpenPickAllowsDirtyWorktreeWhenBranchMatchesTarget(t *testing.T) {
+	m := newModel()
+	m.mode = modeOpen
+	m.openStage = openStagePickWorktree
+	m.openTargetBranch = "feature/existing"
+	m.openPickIndex = 1
+	m.openSlots = []openSlotState{
+		{Path: t.TempDir(), Branch: "feature/existing", Dirty: true},
+	}
+
+	updatedModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedModel.(model)
+	if !updated.openCreating {
+		t.Fatalf("expected selecting dirty matching branch slot to continue")
+	}
+	if updated.warnMsg != "" {
+		t.Fatalf("expected no warning for dirty matching branch slot, got %q", updated.warnMsg)
+	}
+	if cmd == nil {
+		t.Fatalf("expected command to be scheduled")
+	}
+}

--- a/cmd/ui_update_hint.go
+++ b/cmd/ui_update_hint.go
@@ -33,11 +33,11 @@ func formatInteractiveUpdateHint(current string, result updateCheckResult, err e
 	if err != nil {
 		return fmt.Sprintf("wtx update check failed: %v", err), true
 	}
+	if result.UpdateAvailable {
+		return fmt.Sprintf(wtxUpdateCommandFormat, result.CurrentVersion, result.LatestVersion), false
+	}
 	if strings.TrimSpace(result.ResolveError) != "" {
 		return fmt.Sprintf("wtx update check failed: %s", strings.TrimSpace(result.ResolveError)), true
-	}
-	if err == nil && result.UpdateAvailable {
-		return fmt.Sprintf(wtxUpdateCommandFormat, result.CurrentVersion, result.LatestVersion), false
 	}
 	return fmt.Sprintf("wtx %s", current), false
 }

--- a/cmd/ui_update_hint_test.go
+++ b/cmd/ui_update_hint_test.go
@@ -58,3 +58,19 @@ func TestFormatInteractiveUpdateHint_OnResolveFallbackError(t *testing.T) {
 		t.Fatalf("expected error hint")
 	}
 }
+
+func TestFormatInteractiveUpdateHint_ShowsUpdateWhenFallbackHasUpdate(t *testing.T) {
+	got, isErr := formatInteractiveUpdateHint("v1.0.0", updateCheckResult{
+		CurrentVersion:  "v1.0.0",
+		LatestVersion:   "v1.1.0",
+		UpdateAvailable: true,
+		ResolveError:    "network down",
+	}, nil)
+	want := "wtx v1.0.0 -> v1.1.0 available. Run: wtx update"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+	if isErr {
+		t.Fatalf("expected non-error hint")
+	}
+}

--- a/cmd/worktree_manager.go
+++ b/cmd/worktree_manager.go
@@ -180,6 +180,32 @@ func (m *WorktreeManager) ListLocalBranchesByRecentUse() ([]string, error) {
 	return branches, nil
 }
 
+func (m *WorktreeManager) ListAllLocalBranchesByRecentUse() ([]string, error) {
+	gitPath, repoRoot, err := requireGitContext(m.cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := commandOutputInDir(repoRoot, gitPath, "for-each-ref",
+		"--sort=-committerdate",
+		"--format=%(refname:short)",
+		"refs/heads/")
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(output), "\n")
+	branches := make([]string, 0, len(lines))
+	for _, line := range lines {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		branches = append(branches, name)
+	}
+	return branches, nil
+}
+
 func (m *WorktreeManager) DeleteWorktree(path string, force bool) error {
 	path = strings.TrimSpace(path)
 	if path == "" {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -196,6 +196,20 @@ func currentBranch(t *testing.T, path string) string {
 	return runCmd(t, path, nil, "git", "rev-parse", "--abbrev-ref", "HEAD")
 }
 
+func branchExists(t *testing.T, path string, branch string) bool {
+	t.Helper()
+	cmd := exec.Command("git", "show-ref", "--verify", "refs/heads/"+branch)
+	cmd.Dir = path
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return false
+		}
+		t.Fatalf("check branch exists %q failed: %v\n%s", branch, err, string(out))
+	}
+	return true
+}
+
 func TestCompletionInstallAndStatusHermetic(t *testing.T) {
 	t.Parallel()
 	home := t.TempDir()
@@ -259,6 +273,79 @@ func TestCheckoutExistingBranchNonInteractive(t *testing.T) {
 	slotBranch := currentBranch(t, repo.managedWT)
 	if rootBranch != "feature/existing" && slotBranch != "feature/existing" {
 		t.Fatalf("expected feature/existing to be checked out in a worktree, got root=%q slot=%q", rootBranch, slotBranch)
+	}
+}
+
+func TestCheckoutExistingBranchNonInteractive_UsesDirtyAttachedWorktree(t *testing.T) {
+	t.Parallel()
+	repo := setupRepoWithManagedWorktree(t)
+	runCmd(t, repo.managedWT, nil, "git", "checkout", "-b", "feature/dirty-attached")
+	if err := os.WriteFile(filepath.Join(repo.managedWT, "README.md"), []byte("dirty-attached\n"), 0o644); err != nil {
+		t.Fatalf("dirty managed worktree: %v", err)
+	}
+
+	home := t.TempDir()
+	writeConfig(t, home, "true")
+	env := testEnv(home)
+
+	result := runWTX(t, repo.root, env, "checkout", "feature/dirty-attached")
+	if result.err != nil {
+		t.Fatalf("checkout existing dirty attached failed: %v\n%s", result.err, result.out)
+	}
+
+	rootBranch := currentBranch(t, repo.root)
+	slotBranch := currentBranch(t, repo.managedWT)
+	if rootBranch == "feature/dirty-attached" {
+		t.Fatalf("expected root worktree to stay on its branch, got %q", rootBranch)
+	}
+	if slotBranch != "feature/dirty-attached" {
+		t.Fatalf("expected dirty attached worktree to stay selected, got %q", slotBranch)
+	}
+}
+
+func TestCheckoutWithOnlyDirtyWorktreeSelectionRulesNonInteractive(t *testing.T) {
+	t.Parallel()
+	repoRoot := setupSingleWorktreeRepo(t)
+	runCmd(t, repoRoot, nil, "git", "checkout", "-B", "branchA")
+	runCmd(t, repoRoot, nil, "git", "branch", "branchB")
+	if err := os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("dirty-branchA\n"), 0o644); err != nil {
+		t.Fatalf("dirty root worktree: %v", err)
+	}
+
+	home := t.TempDir()
+	writeConfig(t, home, "true")
+	env := testEnv(home)
+
+	// Scenario 1: selecting dirty attached branchA should use that worktree.
+	scenario1 := runWTX(t, repoRoot, env, "checkout", "branchA")
+	if scenario1.err != nil {
+		t.Fatalf("scenario1 failed: %v\n%s", scenario1.err, scenario1.out)
+	}
+	if got := currentBranch(t, repoRoot); got != "branchA" {
+		t.Fatalf("scenario1 expected branchA to remain selected, got %q", got)
+	}
+
+	// Scenario 2: new branch should not reuse the only dirty worktree.
+	scenario2 := runWTX(t, repoRoot, env, "checkout", "-b", "branch-new", "--from", "main", "--no-fetch")
+	if scenario2.err != nil {
+		t.Fatalf("scenario2 failed unexpectedly: %v\n%s", scenario2.err, scenario2.out)
+	}
+	assertContains(t, scenario2.out, "No worktree is available for this target branch.")
+	if got := currentBranch(t, repoRoot); got != "branchA" {
+		t.Fatalf("scenario2 expected branch to remain branchA, got %q", got)
+	}
+	if branchExists(t, repoRoot, "branch-new") {
+		t.Fatalf("scenario2 expected no new branch to be created when only dirty worktree exists")
+	}
+
+	// Scenario 3: selecting existing branchB should behave like scenario2.
+	scenario3 := runWTX(t, repoRoot, env, "checkout", "branchB")
+	if scenario3.err != nil {
+		t.Fatalf("scenario3 failed unexpectedly: %v\n%s", scenario3.err, scenario3.out)
+	}
+	assertContains(t, scenario3.out, "No worktree is available for this target branch.")
+	if got := currentBranch(t, repoRoot); got != "branchA" {
+		t.Fatalf("scenario3 expected branch to remain branchA, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow selecting unclean worktrees when they are already on the target branch
- include unlocked attached branches in main-screen selection even when outside recent-branch limit
- fix interactive update hint precedence so update-available state is shown even when fresh resolve falls back
- lazily load all local branches only after typing in open-screen search
- disable PR enrichment in all-branch search mode and cap matches at 200
- virtualize open-screen branch rendering so selection remains visible and header stays on-screen

## Tests
- go test ./cmd
- make e2e
- added/updated unit tests for open-screen filtering/rendering and update-hint behavior
- added e2e coverage for dirty-worktree selection rules in noninteractive checkout